### PR TITLE
Add todo list app

### DIFF
--- a/blog/settings.py
+++ b/blog/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'useradmin',
     'wupeiqi',
+    'todo',
 ]
 
 MIDDLEWARE = [

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('wq/', include('wupeiqi.urls')),
     path('user/', include('useradmin.urls')),
+    path('todo/', include('todo.urls')),
 ]

--- a/todo/__init__.py
+++ b/todo/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'todo.apps.TodoConfig'

--- a/todo/apps.py
+++ b/todo/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class TodoConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'todo'

--- a/todo/models.py
+++ b/todo/models.py
@@ -1,0 +1,13 @@
+from django.db import models
+
+
+class TodoItem(models.Model):
+    title = models.CharField(max_length=255)
+    completed = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['-created_at']
+
+    def __str__(self):
+        return self.title

--- a/todo/templates/todo/todo_list.html
+++ b/todo/templates/todo/todo_list.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Todo List</title>
+</head>
+<body>
+<h1>Todo List</h1>
+<form method="post">
+    {% csrf_token %}
+    <input type="text" name="title" placeholder="Add a new task">
+    <button type="submit">Add</button>
+</form>
+<ul>
+    {% for item in items %}
+        <li>
+            {% if item.completed %}<s>{{ item.title }}</s>{% else %}{{ item.title }}{% endif %}
+            <a href="{% url 'todo_toggle' item.id %}">[toggle]</a>
+        </li>
+    {% empty %}
+        <li>No tasks</li>
+    {% endfor %}
+</ul>
+</body>
+</html>

--- a/todo/urls.py
+++ b/todo/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path('', views.todo_list, name='todo_list'),
+    path('toggle/<int:item_id>/', views.toggle_complete, name='todo_toggle'),
+]

--- a/todo/views.py
+++ b/todo/views.py
@@ -1,0 +1,20 @@
+from django.shortcuts import render, redirect, get_object_or_404
+
+from .models import TodoItem
+
+
+def todo_list(request):
+    items = TodoItem.objects.all()
+    if request.method == 'POST':
+        title = request.POST.get('title', '').strip()
+        if title:
+            TodoItem.objects.create(title=title)
+        return redirect('todo_list')
+    return render(request, 'todo/todo_list.html', {'items': items})
+
+
+def toggle_complete(request, item_id):
+    item = get_object_or_404(TodoItem, pk=item_id)
+    item.completed = not item.completed
+    item.save()
+    return redirect('todo_list')


### PR DESCRIPTION
## Summary
- create a new `todo` app with CRUD-lite features
- register the new app in `INSTALLED_APPS`
- expose todo URLs via the project router

## Testing
- `python -m py_compile todo/apps.py todo/models.py todo/views.py todo/urls.py blog/settings.py blog/urls.py`

------
https://chatgpt.com/codex/tasks/task_b_685a0dec81e48332ad5e85338d4d4f0a